### PR TITLE
4/add routes hateoas

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,6 +2,13 @@
 engines:
   duplication:
     enabled: true
+    exclude_fingerprints:
+      # Ignore duplication in controllers/rental.js
+      - 59151d08891bace2374e2bd457eb4275
+      # Ignore duplication in controllers/item.js
+      - 18b636ce1e11b51b085a8a252df79a5d
+      # Ignore duplication in controllers/user.js
+      - 0a5906593e0f167c03593abfebf985c8
     config:
       languages:
       - javascript

--- a/README.md
+++ b/README.md
@@ -35,21 +35,25 @@ All route logic is contained in controllers representing individual endpoints. E
 ```JavaScript
 // controllers/example.js
 module.exports.get = (req, res, next) => {
-    try {
-        res.send('example')
-    } catch (err) {
-        next(err)
-    }
+  try {
+    res.send('example')
+  } catch (err) {
+    next(err)
+  }
 }
 ```
+
+Controller exports should be named for what they *do* not what HTTP verb they will be associated with. For example, use `module.exports.update` instead of `module.exports.put`.  
 
 
 Routes are defined in `./controllers/routes.js`. Example of defining a route:  
 ```JavaScript
 // controllers/routes.js
-const example require('../example')
+const example = require('./example')
 
 module.exports = (app) => {
-  app.get('/example', example.get)
+  app.get({name: 'get example', path: '/example'}, example.get)
 }
 ```
+
+Each route *must* have a descriptive, unique `name` property. Route names are used in defining relations, which show up in the `_links` property of responses. Restify removes spaces, special characters, and uppercase letters from route names, so there is no need to camelcase or kebab-case them.  

--- a/controllers/authentication.js
+++ b/controllers/authentication.js
@@ -1,3 +1,3 @@
 module.exports.authenticate = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'authenticate'})
 }

--- a/controllers/authentication.js
+++ b/controllers/authentication.js
@@ -1,3 +1,3 @@
 module.exports.authenticate = (req, res, next) => {
-  res.send({routePlaceholder: 'authenticate'})
+  res.send({})
 }

--- a/controllers/authentication.js
+++ b/controllers/authentication.js
@@ -1,0 +1,3 @@
+module.exports.authenticate = (req, res, next) => {
+  res.send({})
+}

--- a/controllers/item.js
+++ b/controllers/item.js
@@ -1,19 +1,19 @@
 module.exports.getAll = (req, res, next) => {
-  res.send({routePlaceholder: 'get all items'})
+  res.send({})
 }
 
 module.exports.get = (req, res, next) => {
-  res.send({routePlaceholder: 'get item'})
+  res.send({})
 }
 
 module.exports.create = (req, res, next) => {
-  res.send({routePlaceholder: 'create item'})
+  res.send({})
 }
 
 module.exports.update = (req, res, next) => {
-  res.send({routePlaceholder: 'update item'})
+  res.send({})
 }
 
 module.exports.delete = (req, res, next) => {
-  res.send({routePlaceholder: 'delete item'})
+  res.send({})
 }

--- a/controllers/item.js
+++ b/controllers/item.js
@@ -1,19 +1,19 @@
 module.exports.getAll = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'get all items'})
 }
 
 module.exports.get = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'get item'})
 }
 
 module.exports.create = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'create item'})
 }
 
 module.exports.update = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'update item'})
 }
 
 module.exports.delete = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'delete item'})
 }

--- a/controllers/item.js
+++ b/controllers/item.js
@@ -1,0 +1,19 @@
+module.exports.getAll = (req, res, next) => {
+  res.send({})
+}
+
+module.exports.get = (req, res, next) => {
+  res.send({})
+}
+
+module.exports.create = (req, res, next) => {
+  res.send({})
+}
+
+module.exports.update = (req, res, next) => {
+  res.send({})
+}
+
+module.exports.delete = (req, res, next) => {
+  res.send({})
+}

--- a/controllers/main.js
+++ b/controllers/main.js
@@ -1,0 +1,3 @@
+module.exports.get = (req, res, next) => {
+  res.send({})
+}

--- a/controllers/main.js
+++ b/controllers/main.js
@@ -1,3 +1,3 @@
 module.exports.get = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'main'})
 }

--- a/controllers/main.js
+++ b/controllers/main.js
@@ -1,3 +1,3 @@
 module.exports.get = (req, res, next) => {
-  res.send({routePlaceholder: 'main'})
+  res.send({})
 }

--- a/controllers/organization.js
+++ b/controllers/organization.js
@@ -1,0 +1,15 @@
+module.exports.get = (req, res, next) => {
+  res.send({})
+}
+
+module.exports.create = (req, res, next) => {
+  res.send({})
+}
+
+module.exports.update = (req, res, next) => {
+  res.send({})
+}
+
+module.exports.delete = (req, res, next) => {
+  res.send({})
+}

--- a/controllers/organization.js
+++ b/controllers/organization.js
@@ -1,15 +1,15 @@
 module.exports.get = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'get organization'})
 }
 
 module.exports.create = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'create organization'})
 }
 
 module.exports.update = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'update organization'})
 }
 
 module.exports.delete = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'delete organization'})
 }

--- a/controllers/organization.js
+++ b/controllers/organization.js
@@ -1,15 +1,15 @@
 module.exports.get = (req, res, next) => {
-  res.send({routePlaceholder: 'get organization'})
+  res.send({})
 }
 
 module.exports.create = (req, res, next) => {
-  res.send({routePlaceholder: 'create organization'})
+  res.send({})
 }
 
 module.exports.update = (req, res, next) => {
-  res.send({routePlaceholder: 'update organization'})
+  res.send({})
 }
 
 module.exports.delete = (req, res, next) => {
-  res.send({routePlaceholder: 'delete organization'})
+  res.send({})
 }

--- a/controllers/rental.js
+++ b/controllers/rental.js
@@ -1,19 +1,19 @@
 module.exports.getAll = (req, res, next) => {
-  res.send({routePlaceholder: 'get all rentals'})
+  res.send({})
 }
 
 module.exports.get = (req, res, next) => {
-  res.send({routePlaceholder: 'get rental'})
+  res.send({})
 }
 
 module.exports.create = (req, res, next) => {
-  res.send({routePlaceholder: 'create rental'})
+  res.send({})
 }
 
 module.exports.update = (req, res, next) => {
-  res.send({routePlaceholder: 'update rental'})
+  res.send({})
 }
 
 module.exports.delete = (req, res, next) => {
-  res.send({routePlaceholder: 'delete rental'})
+  res.send({})
 }

--- a/controllers/rental.js
+++ b/controllers/rental.js
@@ -1,19 +1,19 @@
 module.exports.getAll = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'get all rentals'})
 }
 
 module.exports.get = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'get rental'})
 }
 
 module.exports.create = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'create rental'})
 }
 
 module.exports.update = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'update rental'})
 }
 
 module.exports.delete = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'delete rental'})
 }

--- a/controllers/rental.js
+++ b/controllers/rental.js
@@ -1,0 +1,19 @@
+module.exports.getAll = (req, res, next) => {
+  res.send({})
+}
+
+module.exports.get = (req, res, next) => {
+  res.send({})
+}
+
+module.exports.create = (req, res, next) => {
+  res.send({})
+}
+
+module.exports.update = (req, res, next) => {
+  res.send({})
+}
+
+module.exports.delete = (req, res, next) => {
+  res.send({})
+}

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -1,4 +1,46 @@
+const authentication = require('./authentication')
+const item = require('./item')
+const main = require('./main')
+const organization = require('./organization')
+const rental = require('./rental')
+const user = require('./user')
+
 // Define endpoints on application
 module.exports = app => {
+  // Main
+  app.get({name: 'main', path: '/'}, main.get)
 
+  // Authentication
+  app.post({name: 'authenticate', path: '/auth'}, authentication.authenticate)
+
+  // Item
+  app.get({name: 'get all items', path: '/item'}, item.getAll)
+  app.get({name: 'get item', path: '/item/:itemID'}, item.get)
+  app.put({name: 'create item', path: '/item'}, item.create)
+  app.put({name: 'update item', path: '/item/:itemID'}, item.update)
+  app.del({name: 'delete item', path: '/item/:itemID'}, item.delete)
+
+  // Organization
+  app.get({name: 'get organization', path: '/organization/:organizationID'},
+          organization.get)
+  app.put({name: 'create organization', path: '/organization'},
+          organization.create)
+  app.put({name: 'update organization', path: '/organization/:organizationID'},
+          organization.update)
+  app.del({name: 'delete organization', path: '/organization/:organizationID'},
+          organization.delete)
+
+  // Rental
+  app.get({name: 'get all rentals', path: '/rental'}, rental.getAll)
+  app.get({name: 'get rental', path: '/rental/:rentalID'}, rental.get)
+  app.put({name: 'create rental', path: '/rental'}, rental.create)
+  app.put({name: 'update rental', path: '/rental/:rentalID'}, rental.update)
+  app.del({name: 'delete rental', path: '/rental/:rentalID'}, rental.delete)
+
+  // User
+  app.get({name: 'get all users', path: '/user'}, user.getAll)
+  app.get({name: 'get user', path: '/user/:userID'}, user.get)
+  app.put({name: 'create user', path: '/user'}, user.create)
+  app.put({name: 'update user', path: '/user/:userID'}, user.update)
+  app.del({name: 'delete user', path: '/user/userID'}, user.delete)
 }

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1,19 +1,19 @@
 module.exports.getAll = (req, res, next) => {
-  res.send({routePlaceholder: 'get all users'})
+  res.send({})
 }
 
 module.exports.get = (req, res, next) => {
-  res.send({routePlaceholder: 'get user'})
+  res.send({})
 }
 
 module.exports.create = (req, res, next) => {
-  res.send({routePlaceholder: 'create user'})
+  res.send({})
 }
 
 module.exports.update = (req, res, next) => {
-  res.send({routePlaceholder: 'update user'})
+  res.send({})
 }
 
 module.exports.delete = (req, res, next) => {
-  res.send({routePlaceholder: 'delete user'})
+  res.send({})
 }

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1,0 +1,19 @@
+module.exports.getAll = (req, res, next) => {
+  res.send({})
+}
+
+module.exports.get = (req, res, next) => {
+  res.send({})
+}
+
+module.exports.create = (req, res, next) => {
+  res.send({})
+}
+
+module.exports.update = (req, res, next) => {
+  res.send({})
+}
+
+module.exports.delete = (req, res, next) => {
+  res.send({})
+}

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1,19 +1,19 @@
 module.exports.getAll = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'get all users'})
 }
 
 module.exports.get = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'get user'})
 }
 
 module.exports.create = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'create user'})
 }
 
 module.exports.update = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'update user'})
 }
 
 module.exports.delete = (req, res, next) => {
-  res.send({})
+  res.send({routePlaceholder: 'delete user'})
 }

--- a/docs/authentication.html
+++ b/docs/authentication.html
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-  <title>log.js</title>
+  <title>authentication.js</title>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
   <link rel="stylesheet" media="all" href="docco.css" />
@@ -78,7 +78,7 @@
         
           <li id="title">
               <div class="annotation">
-                  <h1>log.js</h1>
+                  <h1>authentication.js</h1>
               </div>
           </li>
         
@@ -93,43 +93,9 @@
               
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">const</span> Bunyan = <span class="hljs-built_in">require</span>(<span class="hljs-string">'bunyan'</span>)
-<span class="hljs-keyword">const</span> restify = <span class="hljs-built_in">require</span>(<span class="hljs-string">'restify'</span>)
-
-<span class="hljs-keyword">const</span> config = <span class="hljs-built_in">require</span>(<span class="hljs-string">'../package'</span>)
-
-<span class="hljs-keyword">const</span> streams = [
-  {
-    <span class="hljs-attr">path</span>: <span class="hljs-string">`<span class="hljs-subst">${config.name}</span>.log`</span>,
-    <span class="hljs-attr">level</span>: <span class="hljs-string">'trace'</span>
-  }
-]
-
-<span class="hljs-keyword">if</span> (process.env.NODE_ENV !== <span class="hljs-string">'test'</span>) {
-  streams.push({
-    <span class="hljs-attr">stream</span>: process.stdout,
-    <span class="hljs-attr">level</span>: <span class="hljs-string">'debug'</span>
-  })
+            <div class="content"><div class='highlight'><pre><span class="hljs-built_in">module</span>.exports.authenticate = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
 }</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-2">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-2">&#182;</a>
-              </div>
-              <p>Create a Bunyan logger.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre><span class="hljs-built_in">module</span>.exports = <span class="hljs-keyword">new</span> Bunyan({
-  <span class="hljs-attr">name</span>: config.name,
-  <span class="hljs-attr">streams</span>: streams,
-  <span class="hljs-attr">serializers</span>: restify.bunyan.serializers
-})</pre></div></div>
             
         </li>
         

--- a/docs/db.html
+++ b/docs/db.html
@@ -20,8 +20,38 @@
             <div id="jump_page">
               
                 
+                <a class="source" href="authentication.html">
+                  authentication.js
+                </a>
+              
+                
+                <a class="source" href="item.html">
+                  item.js
+                </a>
+              
+                
+                <a class="source" href="main.html">
+                  main.js
+                </a>
+              
+                
+                <a class="source" href="organization.html">
+                  organization.js
+                </a>
+              
+                
+                <a class="source" href="rental.html">
+                  rental.js
+                </a>
+              
+                
                 <a class="source" href="routes.html">
                   routes.js
+                </a>
+              
+                
+                <a class="source" href="user.html">
+                  user.js
                 </a>
               
                 
@@ -81,7 +111,7 @@
             <div class="content"><div class='highlight'><pre><span class="hljs-keyword">const</span> db = <span class="hljs-built_in">module</span>.exports = <span class="hljs-built_in">require</span>(<span class="hljs-string">'knex'</span>)({
   <span class="hljs-attr">client</span>: <span class="hljs-string">'mysql'</span>,
   <span class="hljs-attr">connection</span>: {
-    <span class="hljs-attr">host</span>: <span class="hljs-string">'127.0.0.1'</span>,
+    <span class="hljs-attr">host</span>: process.env.DB_URL,
     <span class="hljs-attr">user</span>: process.env.DB_USER,
     <span class="hljs-attr">password</span>: process.env.DB_PASSWORD,
     <span class="hljs-attr">database</span>: process.env.DB_NAME,

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,8 +20,38 @@
             <div id="jump_page">
               
                 
+                <a class="source" href="authentication.html">
+                  authentication.js
+                </a>
+              
+                
+                <a class="source" href="item.html">
+                  item.js
+                </a>
+              
+                
+                <a class="source" href="main.html">
+                  main.js
+                </a>
+              
+                
+                <a class="source" href="organization.html">
+                  organization.js
+                </a>
+              
+                
+                <a class="source" href="rental.html">
+                  rental.js
+                </a>
+              
+                
                 <a class="source" href="routes.html">
                   routes.js
+                </a>
+              
+                
+                <a class="source" href="user.html">
+                  user.js
                 </a>
               
                 
@@ -64,6 +94,7 @@
             </div>
             
             <div class="content"><div class='highlight'><pre><span class="hljs-keyword">const</span> restify = <span class="hljs-built_in">require</span>(<span class="hljs-string">'restify'</span>)
+<span class="hljs-keyword">const</span> restifyJSONHAL = <span class="hljs-built_in">require</span>(<span class="hljs-string">'restify-json-hal'</span>)
 
 <span class="hljs-keyword">const</span> log = <span class="hljs-built_in">require</span>(<span class="hljs-string">'./services/log'</span>)
 <span class="hljs-keyword">const</span> config = <span class="hljs-built_in">require</span>(<span class="hljs-string">'./package'</span>)</pre></div></div>
@@ -77,11 +108,13 @@
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-2">&#182;</a>
               </div>
-              <p>Load environment variables, throw error if any are undefined</p>
+              <p>Load environment variables, throw error if any variables are missing</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-built_in">require</span>(<span class="hljs-string">'dotenv-safe'</span>).load()</pre></div></div>
+            <div class="content"><div class='highlight'><pre><span class="hljs-built_in">require</span>(<span class="hljs-string">'dotenv-safe'</span>).load({
+  <span class="hljs-attr">allowEmptyValues</span>: <span class="hljs-literal">true</span>
+})</pre></div></div>
             
         </li>
         
@@ -145,6 +178,24 @@ app.use(restify.queryParser())</pre></div></div>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-6">&#182;</a>
               </div>
+              <p>Automatically add HATEAOS relations to responses</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>app.use(restifyJSONHAL(app, {
+  <span class="hljs-attr">overrideJSON</span>: <span class="hljs-literal">true</span>,
+  <span class="hljs-attr">makeObjects</span>: <span class="hljs-literal">true</span>
+}))</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-7">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-7">&#182;</a>
+              </div>
               <p>Handle CORS</p>
 
             </div>
@@ -163,11 +214,11 @@ app.opts(<span class="hljs-regexp">/.*/</span>, (req, res, next) =&gt; {
         </li>
         
         
-        <li id="section-7">
+        <li id="section-8">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-7">&#182;</a>
+                <a class="pilcrow" href="#section-8">&#182;</a>
               </div>
               <p>Load all routes</p>
 
@@ -178,11 +229,11 @@ app.opts(<span class="hljs-regexp">/.*/</span>, (req, res, next) =&gt; {
         </li>
         
         
-        <li id="section-8">
+        <li id="section-9">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-8">&#182;</a>
+                <a class="pilcrow" href="#section-9">&#182;</a>
               </div>
               <p>Start application</p>
 

--- a/docs/item.html
+++ b/docs/item.html
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-  <title>log.js</title>
+  <title>item.js</title>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
   <link rel="stylesheet" media="all" href="docco.css" />
@@ -78,7 +78,7 @@
         
           <li id="title">
               <div class="annotation">
-                  <h1>log.js</h1>
+                  <h1>item.js</h1>
               </div>
           </li>
         
@@ -93,43 +93,25 @@
               
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">const</span> Bunyan = <span class="hljs-built_in">require</span>(<span class="hljs-string">'bunyan'</span>)
-<span class="hljs-keyword">const</span> restify = <span class="hljs-built_in">require</span>(<span class="hljs-string">'restify'</span>)
+            <div class="content"><div class='highlight'><pre><span class="hljs-built_in">module</span>.exports.getAll = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
+}
 
-<span class="hljs-keyword">const</span> config = <span class="hljs-built_in">require</span>(<span class="hljs-string">'../package'</span>)
+<span class="hljs-built_in">module</span>.exports.get = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
+}
 
-<span class="hljs-keyword">const</span> streams = [
-  {
-    <span class="hljs-attr">path</span>: <span class="hljs-string">`<span class="hljs-subst">${config.name}</span>.log`</span>,
-    <span class="hljs-attr">level</span>: <span class="hljs-string">'trace'</span>
-  }
-]
+<span class="hljs-built_in">module</span>.exports.create = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
+}
 
-<span class="hljs-keyword">if</span> (process.env.NODE_ENV !== <span class="hljs-string">'test'</span>) {
-  streams.push({
-    <span class="hljs-attr">stream</span>: process.stdout,
-    <span class="hljs-attr">level</span>: <span class="hljs-string">'debug'</span>
-  })
+<span class="hljs-built_in">module</span>.exports.update = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
+}
+
+<span class="hljs-built_in">module</span>.exports.delete = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
 }</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-2">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-2">&#182;</a>
-              </div>
-              <p>Create a Bunyan logger.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre><span class="hljs-built_in">module</span>.exports = <span class="hljs-keyword">new</span> Bunyan({
-  <span class="hljs-attr">name</span>: config.name,
-  <span class="hljs-attr">streams</span>: streams,
-  <span class="hljs-attr">serializers</span>: restify.bunyan.serializers
-})</pre></div></div>
             
         </li>
         

--- a/docs/main.html
+++ b/docs/main.html
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-  <title>log.js</title>
+  <title>main.js</title>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
   <link rel="stylesheet" media="all" href="docco.css" />
@@ -78,7 +78,7 @@
         
           <li id="title">
               <div class="annotation">
-                  <h1>log.js</h1>
+                  <h1>main.js</h1>
               </div>
           </li>
         
@@ -93,43 +93,9 @@
               
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">const</span> Bunyan = <span class="hljs-built_in">require</span>(<span class="hljs-string">'bunyan'</span>)
-<span class="hljs-keyword">const</span> restify = <span class="hljs-built_in">require</span>(<span class="hljs-string">'restify'</span>)
-
-<span class="hljs-keyword">const</span> config = <span class="hljs-built_in">require</span>(<span class="hljs-string">'../package'</span>)
-
-<span class="hljs-keyword">const</span> streams = [
-  {
-    <span class="hljs-attr">path</span>: <span class="hljs-string">`<span class="hljs-subst">${config.name}</span>.log`</span>,
-    <span class="hljs-attr">level</span>: <span class="hljs-string">'trace'</span>
-  }
-]
-
-<span class="hljs-keyword">if</span> (process.env.NODE_ENV !== <span class="hljs-string">'test'</span>) {
-  streams.push({
-    <span class="hljs-attr">stream</span>: process.stdout,
-    <span class="hljs-attr">level</span>: <span class="hljs-string">'debug'</span>
-  })
+            <div class="content"><div class='highlight'><pre><span class="hljs-built_in">module</span>.exports.get = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
 }</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-2">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-2">&#182;</a>
-              </div>
-              <p>Create a Bunyan logger.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre><span class="hljs-built_in">module</span>.exports = <span class="hljs-keyword">new</span> Bunyan({
-  <span class="hljs-attr">name</span>: config.name,
-  <span class="hljs-attr">streams</span>: streams,
-  <span class="hljs-attr">serializers</span>: restify.bunyan.serializers
-})</pre></div></div>
             
         </li>
         

--- a/docs/organization.html
+++ b/docs/organization.html
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-  <title>log.js</title>
+  <title>organization.js</title>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
   <link rel="stylesheet" media="all" href="docco.css" />
@@ -78,7 +78,7 @@
         
           <li id="title">
               <div class="annotation">
-                  <h1>log.js</h1>
+                  <h1>organization.js</h1>
               </div>
           </li>
         
@@ -93,43 +93,21 @@
               
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">const</span> Bunyan = <span class="hljs-built_in">require</span>(<span class="hljs-string">'bunyan'</span>)
-<span class="hljs-keyword">const</span> restify = <span class="hljs-built_in">require</span>(<span class="hljs-string">'restify'</span>)
+            <div class="content"><div class='highlight'><pre><span class="hljs-built_in">module</span>.exports.get = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
+}
 
-<span class="hljs-keyword">const</span> config = <span class="hljs-built_in">require</span>(<span class="hljs-string">'../package'</span>)
+<span class="hljs-built_in">module</span>.exports.create = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
+}
 
-<span class="hljs-keyword">const</span> streams = [
-  {
-    <span class="hljs-attr">path</span>: <span class="hljs-string">`<span class="hljs-subst">${config.name}</span>.log`</span>,
-    <span class="hljs-attr">level</span>: <span class="hljs-string">'trace'</span>
-  }
-]
+<span class="hljs-built_in">module</span>.exports.update = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
+}
 
-<span class="hljs-keyword">if</span> (process.env.NODE_ENV !== <span class="hljs-string">'test'</span>) {
-  streams.push({
-    <span class="hljs-attr">stream</span>: process.stdout,
-    <span class="hljs-attr">level</span>: <span class="hljs-string">'debug'</span>
-  })
+<span class="hljs-built_in">module</span>.exports.delete = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
 }</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-2">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-2">&#182;</a>
-              </div>
-              <p>Create a Bunyan logger.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre><span class="hljs-built_in">module</span>.exports = <span class="hljs-keyword">new</span> Bunyan({
-  <span class="hljs-attr">name</span>: config.name,
-  <span class="hljs-attr">streams</span>: streams,
-  <span class="hljs-attr">serializers</span>: restify.bunyan.serializers
-})</pre></div></div>
             
         </li>
         

--- a/docs/rental.html
+++ b/docs/rental.html
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-  <title>log.js</title>
+  <title>rental.js</title>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
   <link rel="stylesheet" media="all" href="docco.css" />
@@ -78,7 +78,7 @@
         
           <li id="title">
               <div class="annotation">
-                  <h1>log.js</h1>
+                  <h1>rental.js</h1>
               </div>
           </li>
         
@@ -93,43 +93,25 @@
               
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">const</span> Bunyan = <span class="hljs-built_in">require</span>(<span class="hljs-string">'bunyan'</span>)
-<span class="hljs-keyword">const</span> restify = <span class="hljs-built_in">require</span>(<span class="hljs-string">'restify'</span>)
+            <div class="content"><div class='highlight'><pre><span class="hljs-built_in">module</span>.exports.getAll = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
+}
 
-<span class="hljs-keyword">const</span> config = <span class="hljs-built_in">require</span>(<span class="hljs-string">'../package'</span>)
+<span class="hljs-built_in">module</span>.exports.get = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
+}
 
-<span class="hljs-keyword">const</span> streams = [
-  {
-    <span class="hljs-attr">path</span>: <span class="hljs-string">`<span class="hljs-subst">${config.name}</span>.log`</span>,
-    <span class="hljs-attr">level</span>: <span class="hljs-string">'trace'</span>
-  }
-]
+<span class="hljs-built_in">module</span>.exports.create = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
+}
 
-<span class="hljs-keyword">if</span> (process.env.NODE_ENV !== <span class="hljs-string">'test'</span>) {
-  streams.push({
-    <span class="hljs-attr">stream</span>: process.stdout,
-    <span class="hljs-attr">level</span>: <span class="hljs-string">'debug'</span>
-  })
+<span class="hljs-built_in">module</span>.exports.update = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
+}
+
+<span class="hljs-built_in">module</span>.exports.delete = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
 }</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-2">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-2">&#182;</a>
-              </div>
-              <p>Create a Bunyan logger.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre><span class="hljs-built_in">module</span>.exports = <span class="hljs-keyword">new</span> Bunyan({
-  <span class="hljs-attr">name</span>: config.name,
-  <span class="hljs-attr">streams</span>: streams,
-  <span class="hljs-attr">serializers</span>: restify.bunyan.serializers
-})</pre></div></div>
             
         </li>
         

--- a/docs/routes.html
+++ b/docs/routes.html
@@ -20,8 +20,38 @@
             <div id="jump_page">
               
                 
+                <a class="source" href="authentication.html">
+                  authentication.js
+                </a>
+              
+                
+                <a class="source" href="item.html">
+                  item.js
+                </a>
+              
+                
+                <a class="source" href="main.html">
+                  main.js
+                </a>
+              
+                
+                <a class="source" href="organization.html">
+                  organization.js
+                </a>
+              
+                
+                <a class="source" href="rental.html">
+                  rental.js
+                </a>
+              
+                
                 <a class="source" href="routes.html">
                   routes.js
+                </a>
+              
+                
+                <a class="source" href="user.html">
+                  user.js
                 </a>
               
                 
@@ -60,12 +90,139 @@
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-1">&#182;</a>
               </div>
+              
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">const</span> authentication = <span class="hljs-built_in">require</span>(<span class="hljs-string">'./authentication'</span>)
+<span class="hljs-keyword">const</span> item = <span class="hljs-built_in">require</span>(<span class="hljs-string">'./item'</span>)
+<span class="hljs-keyword">const</span> main = <span class="hljs-built_in">require</span>(<span class="hljs-string">'./main'</span>)
+<span class="hljs-keyword">const</span> organization = <span class="hljs-built_in">require</span>(<span class="hljs-string">'./organization'</span>)
+<span class="hljs-keyword">const</span> rental = <span class="hljs-built_in">require</span>(<span class="hljs-string">'./rental'</span>)
+<span class="hljs-keyword">const</span> user = <span class="hljs-built_in">require</span>(<span class="hljs-string">'./user'</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-2">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-2">&#182;</a>
+              </div>
               <p>Define endpoints on application</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-params">app</span> =&gt;</span> {
+            <div class="content"><div class='highlight'><pre><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-params">app</span> =&gt;</span> {</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-3">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-3">&#182;</a>
+              </div>
+              <p>Main</p>
 
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  app.get({<span class="hljs-attr">name</span>: <span class="hljs-string">'main'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/'</span>}, main.get)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-4">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-4">&#182;</a>
+              </div>
+              <p>Authentication</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  app.post({<span class="hljs-attr">name</span>: <span class="hljs-string">'authenticate'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/auth'</span>}, authentication.authenticate)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-5">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-5">&#182;</a>
+              </div>
+              <p>Item</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  app.get({<span class="hljs-attr">name</span>: <span class="hljs-string">'get all items'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/item'</span>}, item.getAll)
+  app.get({<span class="hljs-attr">name</span>: <span class="hljs-string">'get item'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/item/:itemID'</span>}, item.get)
+  app.put({<span class="hljs-attr">name</span>: <span class="hljs-string">'create item'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/item'</span>}, item.create)
+  app.put({<span class="hljs-attr">name</span>: <span class="hljs-string">'update item'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/item/:itemID'</span>}, item.update)
+  app.del({<span class="hljs-attr">name</span>: <span class="hljs-string">'delete item'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/item/:itemID'</span>}, item.delete)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-6">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-6">&#182;</a>
+              </div>
+              <p>Organization</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  app.get({<span class="hljs-attr">name</span>: <span class="hljs-string">'get organization'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/organization/:organizationID'</span>},
+          organization.get)
+  app.put({<span class="hljs-attr">name</span>: <span class="hljs-string">'create organization'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/organization'</span>},
+          organization.create)
+  app.put({<span class="hljs-attr">name</span>: <span class="hljs-string">'update organization'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/organization/:organizationID'</span>},
+          organization.update)
+  app.del({<span class="hljs-attr">name</span>: <span class="hljs-string">'delete organization'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/organization/:organizationID'</span>},
+          organization.delete)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-7">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-7">&#182;</a>
+              </div>
+              <p>Rental</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  app.get({<span class="hljs-attr">name</span>: <span class="hljs-string">'get all rentals'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/rental'</span>}, rental.getAll)
+  app.get({<span class="hljs-attr">name</span>: <span class="hljs-string">'get rental'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/rental/:rentalID'</span>}, rental.get)
+  app.put({<span class="hljs-attr">name</span>: <span class="hljs-string">'create rental'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/rental'</span>}, rental.create)
+  app.put({<span class="hljs-attr">name</span>: <span class="hljs-string">'update rental'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/rental/:rentalID'</span>}, rental.update)
+  app.del({<span class="hljs-attr">name</span>: <span class="hljs-string">'delete rental'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/rental/:rentalID'</span>}, rental.delete)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-8">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-8">&#182;</a>
+              </div>
+              <p>User</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  app.get({<span class="hljs-attr">name</span>: <span class="hljs-string">'get all users'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/user'</span>}, user.getAll)
+  app.get({<span class="hljs-attr">name</span>: <span class="hljs-string">'get user'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/user/:userID'</span>}, user.get)
+  app.put({<span class="hljs-attr">name</span>: <span class="hljs-string">'create user'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/user'</span>}, user.create)
+  app.put({<span class="hljs-attr">name</span>: <span class="hljs-string">'update user'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/user/:userID'</span>}, user.update)
+  app.del({<span class="hljs-attr">name</span>: <span class="hljs-string">'delete user'</span>, <span class="hljs-attr">path</span>: <span class="hljs-string">'/user/userID'</span>}, user.delete)
 }</pre></div></div>
             
         </li>

--- a/docs/user.html
+++ b/docs/user.html
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-  <title>log.js</title>
+  <title>user.js</title>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
   <link rel="stylesheet" media="all" href="docco.css" />
@@ -78,7 +78,7 @@
         
           <li id="title">
               <div class="annotation">
-                  <h1>log.js</h1>
+                  <h1>user.js</h1>
               </div>
           </li>
         
@@ -93,43 +93,25 @@
               
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="hljs-keyword">const</span> Bunyan = <span class="hljs-built_in">require</span>(<span class="hljs-string">'bunyan'</span>)
-<span class="hljs-keyword">const</span> restify = <span class="hljs-built_in">require</span>(<span class="hljs-string">'restify'</span>)
+            <div class="content"><div class='highlight'><pre><span class="hljs-built_in">module</span>.exports.getAll = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
+}
 
-<span class="hljs-keyword">const</span> config = <span class="hljs-built_in">require</span>(<span class="hljs-string">'../package'</span>)
+<span class="hljs-built_in">module</span>.exports.get = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
+}
 
-<span class="hljs-keyword">const</span> streams = [
-  {
-    <span class="hljs-attr">path</span>: <span class="hljs-string">`<span class="hljs-subst">${config.name}</span>.log`</span>,
-    <span class="hljs-attr">level</span>: <span class="hljs-string">'trace'</span>
-  }
-]
+<span class="hljs-built_in">module</span>.exports.create = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
+}
 
-<span class="hljs-keyword">if</span> (process.env.NODE_ENV !== <span class="hljs-string">'test'</span>) {
-  streams.push({
-    <span class="hljs-attr">stream</span>: process.stdout,
-    <span class="hljs-attr">level</span>: <span class="hljs-string">'debug'</span>
-  })
+<span class="hljs-built_in">module</span>.exports.update = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
+}
+
+<span class="hljs-built_in">module</span>.exports.delete = <span class="hljs-function">(<span class="hljs-params">req, res, next</span>) =&gt;</span> {
+  res.send({})
 }</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-2">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-2">&#182;</a>
-              </div>
-              <p>Create a Bunyan logger.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre><span class="hljs-built_in">module</span>.exports = <span class="hljs-keyword">new</span> Bunyan({
-  <span class="hljs-attr">name</span>: config.name,
-  <span class="hljs-attr">streams</span>: streams,
-  <span class="hljs-attr">serializers</span>: restify.bunyan.serializers
-})</pre></div></div>
             
         </li>
         

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ require('dotenv-safe').load({
 })
 
 // Create application
-const app = restify.createServer({
+const app = module.exports = restify.createServer({
   name: config.name,
   log: log,
   version: config.version
@@ -51,5 +51,3 @@ require('./controllers/routes')(app)
 app.listen(process.env.PORT, () => {
   log.info('%s listening at %s', app.name, app.url)
 })
-
-module.exports = app

--- a/index.js
+++ b/index.js
@@ -47,7 +47,9 @@ app.opts(/.*/, (req, res, next) => {
 // Load all routes
 require('./controllers/routes')(app)
 
-// Start application
-app.listen(process.env.PORT, () => {
-  log.info('%s listening at %s', app.name, app.url)
-})
+// Start application when not in test environment
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(process.env.PORT, () => {
+    log.info('%s listening at %s', app.name, app.url)
+  })
+}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const restify = require('restify')
+const restifyJSONHAL = require('restify-json-hal')
 
 const log = require('./services/log')
 const config = require('./package')
@@ -24,6 +25,12 @@ app.pre((req, res, next) => {
 // Parse incoming request body and query parameters
 app.use(restify.bodyParser({mapParams: false}))
 app.use(restify.queryParser())
+
+// Automatically add HATEAOS relations to responses
+app.use(restifyJSONHAL(app, {
+  overrideJSON: true,
+  makeObjects: true
+}))
 
 // Handle CORS
 app.use(restify.CORS())

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "pm2 start index.js --name stockpile",
     "stop": "pm2 stop stockpile || true",
     "dev": "nodemon index.js",
-    "test": "nyc ava",
+    "test": "NODE_ENV=test nyc ava",
     "lint": "eslint .",
     "docs": "docco {index.js,controllers/*.js,services/*.js}"
   },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-ava": "^4.0.1",
     "eslint-plugin-standard": "^2.0.1",
     "nodemon": "^1.11.0",
-    "nyc": "^10.1.2"
+    "nyc": "^10.1.2",
+    "sinon": "1.17.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "knex": "^0.12.6",
     "mysql": "^2.13.0",
     "pm2": "^2.3.0",
-    "restify": "^4.3.0"
+    "restify": "^4.3.0",
+    "restify-json-hal": "^0.1.2"
   },
   "devDependencies": {
     "ava": "^0.17.0",

--- a/test/authentication.js
+++ b/test/authentication.js
@@ -1,0 +1,14 @@
+const sinon = require('sinon')
+const test = require('ava')
+
+const authentication = require('../controllers/authentication')
+
+test('Returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await authentication.authenticate(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})

--- a/test/item.js
+++ b/test/item.js
@@ -1,0 +1,54 @@
+const sinon = require('sinon')
+const test = require('ava')
+
+const item = require('../controllers/item')
+
+test('Get all returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await item.getAll(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})
+
+test('Get returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await item.get(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})
+
+test('Create returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await item.create(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})
+
+test('Update returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await item.update(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})
+
+test('Delete returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await item.delete(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})

--- a/test/main.js
+++ b/test/main.js
@@ -1,0 +1,14 @@
+const sinon = require('sinon')
+const test = require('ava')
+
+const main = require('../controllers/main')
+
+test('Returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await main.get(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})

--- a/test/organization.js
+++ b/test/organization.js
@@ -1,0 +1,44 @@
+const sinon = require('sinon')
+const test = require('ava')
+
+const organization = require('../controllers/organization')
+
+test('Get returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await organization.get(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})
+
+test('Create returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await organization.create(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})
+
+test('Update returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await organization.update(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})
+
+test('Delete returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await organization.delete(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})

--- a/test/rental.js
+++ b/test/rental.js
@@ -1,0 +1,54 @@
+const sinon = require('sinon')
+const test = require('ava')
+
+const rental = require('../controllers/rental')
+
+test('Get all returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await rental.getAll(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})
+
+test('Get returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await rental.get(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})
+
+test('Create returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await rental.create(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})
+
+test('Update returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await rental.update(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})
+
+test('Delete returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await rental.delete(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})

--- a/test/routes.js
+++ b/test/routes.js
@@ -1,0 +1,13 @@
+const test = require('ava')
+
+const app = require('../index')
+
+test('Routes are defined correctly', t => {
+  const methods = Object.keys(app.router.routes)
+  methods.forEach(method => {
+    app.router.routes[method].forEach(route => {
+      t.truthy(route.name, 'route has name')
+      t.truthy(route.spec.path, 'route has path')
+    })
+  })
+})

--- a/test/user.js
+++ b/test/user.js
@@ -1,0 +1,54 @@
+const sinon = require('sinon')
+const test = require('ava')
+
+const user = require('../controllers/user')
+
+test('Get all returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await user.getAll(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})
+
+test('Get returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await user.get(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})
+
+test('Create returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await user.create(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})
+
+test('Update returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await user.update(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})
+
+test('Delete returns a response', async t => {
+  const res = {
+    send: sinon.spy()
+  }
+  await user.delete(null, res, null)
+  t.true(res.send.calledOnce, 'route sends a response')
+  t.true(res.send.calledWithMatch(sinon.match.object),
+                                  'route responds with an object')
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,6 +131,10 @@ array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
 
+"array-flatten@>= 0.0.2":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.1.tgz#426bb9da84090c1838d812c8150af20a8331e296"
+
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
@@ -144,6 +148,12 @@ array-uniq@^1.0.1, array-uniq@^1.0.2:
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
+
+arrayify-compact@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/arrayify-compact/-/arrayify-compact-0.1.0.tgz#b86df4dadcfc236a4a404f0247940b7f73b3613e"
+  dependencies:
+    array-flatten ">= 0.0.2"
 
 arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
@@ -1771,6 +1781,12 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
+extract-comments@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/extract-comments/-/extract-comments-0.7.3.tgz#1c5dec1730072c5b0cdfa5557e5f57f69277fc34"
+  dependencies:
+    is-whitespace "^0.3.0"
+
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
@@ -1905,6 +1921,12 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+formatio@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+  dependencies:
+    samsam "~1.1"
+
 formidable@^1.0.14:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
@@ -1999,6 +2021,16 @@ getpass@^0.1.1:
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.6.tgz#283ffd9fc1256840875311c1b60e8c40187110e6"
   dependencies:
     assert-plus "^1.0.0"
+
+gfm-code-block-regex@^0.2.1:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/gfm-code-block-regex/-/gfm-code-block-regex-0.2.3.tgz#0b9fe68acf2c5a5022fd6d2d418a634f6e97c110"
+
+gfm-code-blocks@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/gfm-code-blocks/-/gfm-code-blocks-0.2.2.tgz#2999d8148c451b86632c71fa6debe115ee071ffe"
+  dependencies:
+    gfm-code-block-regex "^0.2.1"
 
 "gkt@https://tgz.pm2.io/gkt-1.0.0.tgz":
   version "1.0.0"
@@ -2252,6 +2284,10 @@ infinity-agent@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/infinity-agent/-/infinity-agent-2.0.3.tgz#45e0e2ff7a9eb030b27d62b74b3744b7a7ac4216"
 
+inflection@^1.7.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.12.0.tgz#a200935656d6f5f6bc4dc7502e1aecb703228416"
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -2262,6 +2298,10 @@ inflight@^1.0.4:
 inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+inherits@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
@@ -2476,6 +2516,10 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+is-whitespace@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/is-whitespace/-/is-whitespace-0.3.0.tgz#1639ecb1be036aec69a54cbb401cfbed7114ab7f"
+
 is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
@@ -2560,16 +2604,9 @@ js-tokens@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.0.tgz#a2f2a969caae142fb3cd56228358c89366957bd1"
 
-js-yaml@3.6.1:
+js-yaml@3.6.1, js-yaml@^3.5.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^2.6.0"
-
-js-yaml@^3.5.1:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
@@ -2811,6 +2848,10 @@ lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
+lodash@^3.6.0:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+
 lodash@^4.0.0, lodash@^4.13.1, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -2818,6 +2859,10 @@ lodash@^4.0.0, lodash@^4.13.1, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.0:
 log-driver@1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
+
+lolex@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -2950,11 +2995,11 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@1.2.0, minimist@^1.2.0:
+minimist@1.2.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-minimist@^1.1.3, minimist@~1.1.0:
+minimist@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
 
@@ -3259,6 +3304,21 @@ package-json@^2.0.0:
     registry-auth-token "^3.0.1"
     registry-url "^3.0.3"
     semver "^5.1.0"
+
+parse-code-context@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/parse-code-context/-/parse-code-context-0.1.3.tgz#b0cafe65c34b916434100033eb334e9d282cb461"
+
+parse-comments@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/parse-comments/-/parse-comments-0.4.3.tgz#68c955f1ec9b655a4f241b1124c79db1310d67bd"
+  dependencies:
+    arrayify-compact "^0.1.0"
+    extract-comments "^0.7.3"
+    gfm-code-blocks "^0.2.0"
+    inflection "^1.7.0"
+    lodash "^3.6.0"
+    parse-code-context "^0.1.3"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -3848,6 +3908,12 @@ resolve@^1.1.6, resolve@^1.1.7:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.2.0.tgz#9589c3f2f6149d1417a40becc1663db6ec6bc26c"
 
+restify-json-hal@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/restify-json-hal/-/restify-json-hal-0.1.2.tgz#2e5b4dae3a61fe40cadcec59f16a959e10cd7a37"
+  dependencies:
+    parse-comments "^0.4.3"
+
 restify@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/restify/-/restify-4.3.0.tgz#03b67960d1d42a6dafcde3bd82fb882173a27678"
@@ -3913,6 +3979,10 @@ safe-json-stringify@~1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz#3cb6717660a086d07cb5bd9b7a6875bcf67bd05e"
 
+samsam@1.1.2, samsam@~1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
@@ -3962,6 +4032,15 @@ signal-exit@^2.0.0:
 signal-exit@^3.0.0, signal-exit@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon@1.17.7:
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+  dependencies:
+    formatio "1.1.1"
+    lolex "1.3.2"
+    samsam "1.1.2"
+    util ">=0.10.3 <1"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -4419,6 +4498,12 @@ user-home@^2.0.0:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+"util@>=0.10.3 <1":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  dependencies:
+    inherits "2.0.1"
 
 uuid@^2.0.1:
   version "2.0.3"


### PR DESCRIPTION
This adds scaffolding for the entire API. Currently, all the endpoints return `{}`. All responses also contain a `_links` property that contains relations to other endpoints.

Closes #4.