### PR TITLE
Remove CORS support

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,18 +32,6 @@ app.use(restifyJSONHAL(app, {
   makeObjects: true
 }))
 
-// Handle CORS
-app.use(restify.CORS())
-app.opts(/.*/, (req, res, next) => {
-  res.header('Access-Control-Allow-Origin', '*')
-  res.header('Access-Control-Allow-Methods',
-             req.header('Access-Control-Request-Method'))
-  res.header('Access-Control-Allow-Headers',
-             req.header('Access-Control-Request-Headers'))
-  res.send(200)
-  return next()
-})
-
 // Load all routes
 require('./controllers/routes')(app)
 


### PR DESCRIPTION
This removes the automatic addition of CORS headers to `OPTIONS` requests for every endpoint.

Closes #35.