### PR TITLE
46/remove stdout logging stream

### DIFF
--- a/services/log.js
+++ b/services/log.js
@@ -10,13 +10,6 @@ const streams = [
   }
 ]
 
-if (process.env.NODE_ENV !== 'test') {
-  streams.push({
-    stream: process.stdout,
-    level: 'debug'
-  })
-}
-
 // Create a Bunyan logger.
 module.exports = new Bunyan({
   name: config.name,


### PR DESCRIPTION
The reason for the low test coverage in the log service is the
conditional that is not executed in the test environment. All this
conditional did was add a log output for `stdout`, which is functionally
useless because it outputs JSON to the console. Removing the `stdout`
stream serves to both increase test coverage and remove an annoyance
when running the application.

Closes #46.