### PR TITLE
34/add index tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,10 +17,7 @@ const app = module.exports = restify.createServer({
 })
 
 // Log every incoming request
-app.pre((req, res, next) => {
-  req.log.info({req}, 'start')
-  return next()
-})
+app.pre(log.onRequest)
 
 // Parse incoming request body and query parameters
 app.use(restify.bodyParser({mapParams: false}))
@@ -35,9 +32,8 @@ app.use(restifyJSONHAL(app, {
 // Load all routes
 require('./controllers/routes')(app)
 
-// Start application when not in test environment
-if (process.env.NODE_ENV !== 'test') {
-  app.listen(process.env.PORT, () => {
-    log.info('%s listening at %s', app.name, app.url)
-  })
+// Check if application should start
+if (!process.env.NO_START) {
+  // Start application
+  app.listen(process.env.PORT, log.onAppStart.bind(null, app))
 }

--- a/services/log.js
+++ b/services/log.js
@@ -18,8 +18,17 @@ if (process.env.NODE_ENV !== 'test') {
 }
 
 // Create a Bunyan logger.
-module.exports = new Bunyan({
+const log = module.exports = new Bunyan({
   name: config.name,
   streams: streams,
   serializers: restify.bunyan.serializers
 })
+
+module.exports.onRequest = (req, res, next) => {
+  req.log.info({req}, 'start')
+  return next()
+}
+
+module.exports.onAppStart = (app) => {
+  log.info('%s listening at %s', app.name, app.url)
+}

--- a/test/fixtures/log.json
+++ b/test/fixtures/log.json
@@ -1,0 +1,6 @@
+{
+  "app": {
+    "name": "testApp",
+    "url": "localhost:9999"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,7 @@
+const test = require('ava')
+
+const app = require('../index')
+
+test('Exports Restify application', t => {
+  t.truthy(app)
+})

--- a/test/log.js
+++ b/test/log.js
@@ -1,7 +1,31 @@
+const sinon = require('sinon')
 const test = require('ava')
 
+const d = require('./fixtures/log')
 const log = require('../services/log')
 
 test('Log exports an object', t => {
   t.true(typeof log === 'object')
+})
+
+test('Logs request', t => {
+  const req = {
+    log: {
+      info: sinon.spy()
+    }
+  }
+  const next = sinon.spy()
+  log.onRequest(req, null, next)
+  t.true(req.log.info.calledOnce, 'should output to log once')
+  t.true(req.log.info.calledWithExactly({req}, sinon.match.string),
+         'should log request with description')
+  t.true(next.calledOnce, 'should call next() once')
+})
+
+test('Logs app start', t => {
+  const logSpy = sinon.spy(log, 'info')
+  log.onAppStart(d.app)
+  t.true(logSpy.calledOnce, 'should output to log once')
+  t.true(logSpy.calledWith(sinon.match.string, d.app.name, d.app.url),
+        'should log application name and URL')
 })

--- a/test/routes.js
+++ b/test/routes.js
@@ -1,5 +1,7 @@
 const test = require('ava')
 
+// Do not start application when importing it
+process.env.NO_START = true
 const app = require('../index')
 
 test('Routes are defined correctly', t => {


### PR DESCRIPTION
Closes #34.

This brings test coverage for `index.js` up to 100%, and maintains the test coverage of the log service.