### PR TITLE
52/Add OPTIONS handling for all endpoints

### DIFF
--- a/controllers/options.js
+++ b/controllers/options.js
@@ -1,0 +1,12 @@
+const restify = require('restify')
+
+module.exports = (req, res, next) => {
+  // Handle OPTIONS requests
+  if (req.method.toLowerCase() === 'options') {
+    return res.send(204)
+
+  // If not OPTIONS request, rethrow error
+  } else {
+    return res.send(new restify.MethodNotAllowedError())
+  }
+}

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const restifyJSONHAL = require('restify-json-hal')
 
 const auth = require('./controllers/auth')
 const config = require('./package')
+const handleOptions = require('./controllers/options')
 const log = require('./services/log')
 
 // Load environment variables, throw error if any variables are missing
@@ -23,6 +24,9 @@ app.pre(log.onRequest)
 // Parse incoming request body and query parameters
 app.use(restify.bodyParser({mapParams: false}))
 app.use(restify.queryParser())
+
+// Handle OPTIONS requests and method not allowed errors
+app.on('MethodNotAllowed', handleOptions)
 
 // Automatically add HATEAOS relations to responses
 app.use(restifyJSONHAL(app, {

--- a/test/fixtures/options.json
+++ b/test/fixtures/options.json
@@ -1,0 +1,8 @@
+{
+  "reqOptions": {
+    "method": "OPTIONS"
+  },
+  "req": {
+    "method": "PATCH"
+  }
+}

--- a/test/options.js
+++ b/test/options.js
@@ -1,0 +1,26 @@
+const restify = require('restify')
+const sinon = require('sinon')
+const test = require('ava')
+
+const d = require('./fixtures/options')
+const handleOptions = require('../controllers/options')
+
+test('Responds with 204 NO CONTENT when method is OPTIONS', t => {
+  const res = {
+    send: sinon.spy()
+  }
+  handleOptions(d.reqOptions, res, null)
+  t.true(res.send.called, 'response sent')
+  t.true(res.send.calledWithMatch(sinon.match.same(204)),
+         'responds with 204')
+})
+
+test('Responds with 405 METHOD NOT ALLOWED when method is not OPTIONS', t => {
+  const res = {
+    send: sinon.spy()
+  }
+  handleOptions(d.req, res, null)
+  t.true(res.send.called, 'response sent')
+  t.true(res.send.calledWithMatch(new restify.MethodNotAllowedError()),
+         'responds with Restify 405 error')
+})


### PR DESCRIPTION
Intercept `MethodNotAllowed` errors, check if the current request method
is `OPTIONS`, and if it is, return an appropriate response.

Closes #52.