### PR TITLE
56/Remove token generation from auth.register()

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -64,10 +64,8 @@ module.exports.register = (req, res, next) => {
       })
       .then(id => {
         const organizationID = id[0]
-        const token = makeToken({sub: organizationID})
         res.send(201, {
           id: organizationID,
-          token,
           message: 'created organization'
         })
       })


### PR DESCRIPTION
This more closely mirrors the flow of actions in the front end, where
the user first registers then must log in with his or her credentials,
at which point an authentication token is received and cached in the
front end.

Closes #56.