### PR TITLE
66/add token error handling

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -43,7 +43,7 @@ module.exports.authenticate = (req, res, next) => {
       })
       .catch(next)
   } else {
-    return next(new restify.UnprocessableEntityError('missing required fields'))
+    return next(new restify.BadRequestError('missing required fields'))
   }
 }
 
@@ -71,7 +71,7 @@ module.exports.register = (req, res, next) => {
       })
       .catch(next)
   } else {
-    return next(new restify.UnprocessableEntityError())
+    return next(new restify.BadRequestError())
   }
 }
 

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -64,10 +64,14 @@ module.exports.register = (req, res, next) => {
       })
       .then(id => {
         const organizationID = id[0]
-        res.send(201, {
-          id: organizationID,
-          message: 'created organization'
-        })
+        if (organizationID) {
+          return res.send(201, {
+            id: organizationID,
+            message: 'created organization'
+          })
+        } else {
+          return next(new restify.InternalServerError('organization not created'))
+        }
       })
       .catch(next)
   } else {

--- a/test/auth.js
+++ b/test/auth.js
@@ -46,7 +46,7 @@ test('Returns error when registering organization with missing data', async t =>
   t.false(res.send.called, 'does not send response')
   t.true(
     next.calledWithMatch(
-      sinon.match.instanceOf(restify.UnprocessableEntityError)),
+      sinon.match.instanceOf(restify.BadRequestError)),
     'returns error')
 })
 


### PR DESCRIPTION
Closes #66 and #73.

Adds a couple of error cases and improves existing error handling. Also fixes the problem with tokens being generated without an organization ID encoded in them.