### PR TITLE
77/Change from itemID to tag on item endpoints

### DIFF
--- a/controllers/item.js
+++ b/controllers/item.js
@@ -1,10 +1,10 @@
 const endpoint = require('../services/endpoint')
 
 const table = 'item'
-const primaryKey = 'itemID'
+const key = 'tag'
 
 module.exports.getAll = endpoint.getAll(table)
-module.exports.get = endpoint.get(table, primaryKey)
+module.exports.get = endpoint.get(table, key)
 module.exports.create = endpoint.create(table, 'item created')
-module.exports.update = endpoint.update(table)
-module.exports.delete = endpoint.delete(table, primaryKey, 'item deleted')
+module.exports.update = endpoint.update(table, key)
+module.exports.delete = endpoint.delete(table, key, 'item deleted')

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -17,10 +17,10 @@ module.exports = app => {
 
   // Item
   app.get({name: 'get all items', path: 'item'}, auth.verify, item.getAll)
-  app.get({name: 'get item', path: 'item/:itemID'}, auth.verify, item.get)
+  app.get({name: 'get item', path: 'item/:tag'}, auth.verify, item.get)
   app.put({name: 'create item', path: 'item'}, auth.verify, item.create)
-  app.put({name: 'update item', path: 'item/:itemID'}, auth.verify, item.update)
-  app.del({name: 'delete item', path: 'item/:itemID'}, auth.verify, item.delete)
+  app.put({name: 'update item', path: 'item/:tag'}, auth.verify, item.update)
+  app.del({name: 'delete item', path: 'item/:tag'}, auth.verify, item.delete)
 
   // Organization
   app.get({name: 'get organization', path: 'organization/:organizationID'},


### PR DESCRIPTION
This is more convenient for the frontend, which will need to access
items by tag, because that is how the user will scan items in. The
`itemID` field is still the primary key instead of `tag`, however,
because it is a smaller value than the `tag` column and therefore will
index more efficiently and help keep database size small.

Closes #77.