### PR TITLE
76/Add organization ID to created rows if missing

### DIFF
--- a/services/endpoint.js
+++ b/services/endpoint.js
@@ -61,6 +61,11 @@ module.exports.get = (tableName, columnName, paramName) => {
  */
 module.exports.create = (tableName, message) => {
   return (req, res, next) => {
+    // Add organization ID if it is missing
+    if (!req.body.organizationID) {
+      req.body.organizationID = req.user.organizationID
+    }
+
     return db.create(tableName, req.body)
       .then(([id]) => res.send({
         id,


### PR DESCRIPTION
This is a brittle change because it presumes that all database tables
have a column called `organizationID`, but it works for now and would
require significant added complexity to add the same functionality in a
less brittle way.

Closes #76.