### PR TITLE
84/Change endpoint.getAll() property to "results"

### DIFF
--- a/services/endpoint.js
+++ b/services/endpoint.js
@@ -7,22 +7,6 @@
 const db = require('../services/db')
 
 /**
- * Make a response object
- * @param {string} prop Property name
- * @param {any} data Arbitrary data
- * @return {object} Response object with data assigned to prop
- */
-const makeResponse = module.exports.makeResponse = (prop, data) => {
-  if (prop && data) {
-    const response = {}
-    response[prop] = data
-    return response
-  } else {
-    throw new Error('cannot make response without both property and data')
-  }
-}
-
-/**
  * Get all rows from a table and return them in an object, assigned to a
  * property with the same name as the table
  * @param {string} tableName Name of a database table
@@ -31,7 +15,7 @@ const makeResponse = module.exports.makeResponse = (prop, data) => {
 module.exports.getAll = (tableName) => {
   return (req, res, next) => {
     return db.getAll(tableName, req.user.organizationID)
-      .then(rows => res.send(makeResponse(tableName, rows)))
+      .then(rows => res.send({results: rows}))
       .catch(next)
   }
 }

--- a/test/endpoint.js
+++ b/test/endpoint.js
@@ -30,8 +30,8 @@ test('Get all', async t => {
   t.true(res.send.calledWithMatch(sinon.match.object),
          'responds with an object')
   // Two items inserted, so should be two or more in the table
-  t.true(res.send.calledWithMatch(sinon.match(result =>
-                                              result[d.table].length >= 2)),
+  t.true(res.send.calledWithMatch(sinon.match(response =>
+                                              response.results.length >= 2)),
          'responds with the right number of items')
   t.false(next.called, 'no errors')
 })

--- a/test/endpoint.js
+++ b/test/endpoint.js
@@ -14,13 +14,6 @@ test.before('Set up test table', async t => {
   })
 })
 
-test('Make response', t => {
-  const actualResponse = endpoint.makeResponse(d.makeResponse.prop,
-                                               d.makeResponse.data)
-  t.deepEqual(actualResponse, d.makeResponse.expected,
-              'makes response correctly')
-})
-
 test('Get all', async t => {
   // Insert multiple rows
   await knex(d.table).insert(d.multipleRows)


### PR DESCRIPTION
This removes the need for `endpoint.makeResponse()`, which was intended
to provide a simple way to wrap results in an object under a given
property.

Closes #84.