### PR TITLE
100/add join to endpoint service

### DIFF
--- a/controllers/item.js
+++ b/controllers/item.js
@@ -3,7 +3,31 @@ const endpoint = require('../services/endpoint')
 
 const item = module.exports
 
+// Join item with all of its fields
+item.withFields = (queryBuilder) => {
+  return queryBuilder
+    .select('item.*')
+
+  // Status
+    .leftJoin('status', 'item.statusID', 'status.statusID')
+    .select('status.name as status')
+
+  // Brand
+    .leftJoin('brand', 'item.brandID', 'brand.brandID')
+    .select('brand.name as brand')
+
+  // Model
+    .leftJoin('model', 'item.modelID', 'model.modelID')
+    .select('model.name as model')
+
+  // Category
+    .leftJoin('category', 'item.categoryID', 'category.categoryID')
+    .select('category.name as category')
+}
+
 endpoint.addAllMethods(item, 'item', 'tag')
+item.getAll = endpoint.getAll('item', item.withFields)
+item.get = endpoint.get('item', 'tag', item.withFields)
 
 item.mount = app => {
   app.get({name: 'get all items', path: 'item'}, auth.verify, item.getAll)

--- a/controllers/rental.js
+++ b/controllers/rental.js
@@ -3,15 +3,25 @@ const endpoint = require('../services/endpoint')
 
 const rental = module.exports
 
-endpoint.addAllMethods(rental, 'rental', 'rentalID')
+// Join rental with item to get the item's tag
+rental.withTag = (queryBuilder) => {
+  return queryBuilder
+    .select('rental.*')
+    .leftJoin('item', 'rental.itemID', 'item.itemID')
+    .select('item.tag')
+}
+
+endpoint.addAllMethods(rental, 'rental', 'tag')
+rental.getAll = endpoint.getAll('rental', rental.withTag)
+rental.get = endpoint.get('rental', 'tag', rental.withTag)
 
 rental.mount = app => {
   app.get({name: 'get all rentals', path: 'rental'}, auth.verify, rental.getAll)
-  app.get({name: 'get rental', path: 'rental/:rentalID'},
+  app.get({name: 'get rental', path: 'rental/:tag'},
           auth.verify, rental.get)
   app.put({name: 'create rental', path: 'rental'}, auth.verify, rental.create)
-  app.put({name: 'update rental', path: 'rental/:rentalID'},
+  app.put({name: 'update rental', path: 'rental/:tag'},
           auth.verify, rental.update)
-  app.del({name: 'delete rental', path: 'rental/:rentalID'},
+  app.del({name: 'delete rental', path: 'rental/:tag'},
           auth.verify, rental.delete)
 }

--- a/services/db.js
+++ b/services/db.js
@@ -47,9 +47,10 @@ db.buildWhere = (table, column, value, organizationID) => {
  * Create a row or rows in a table
  * @param {string} table Name of a database table
  * @param {object|array} data Row or rows to insert
+ * @param {function} [modify=noop] Modify the query
  * @return {Promise.<object>} Resolved by result from database
  */
-db.create = (table, data) => {
+db.create = (table, data, modify = () => {}) => {
   if (data) {
     return db(table)
       .insert(data)
@@ -70,11 +71,12 @@ db.create = (table, data) => {
  * @param {string} table Name of a database table
  * @param {string} column Indexed column in database table
  * @param {any} value Value in column to look for
- * @param {any} organizationID ID of organization
+ * @param {any} [organizationID] ID of organization
+ * @param {function} [modify=noop] Modify the query
  * @return {Promise.<boolean>} True if operation completed succesfully
  * @throws restify.NotFoundError when row to delete does not exist
  */
-db.delete = (table, column, value, organizationID) => {
+db.delete = (table, column, value, organizationID, modify = () => {}) => {
   return db(table)
     .where(db.buildWhere(table, column, value, organizationID))
     .delete()
@@ -105,7 +107,7 @@ db.get = (table, column, value, organizationID, modify = () => {}) => {
 /**
  * Get all rows from table
  * @param {string} table Name of a database table
- * @param {any} organizationID ID of organization
+ * @param {any} [organizationID] ID of organization
  * @param {function} [modify=noop] Modify the query
  * @return {Promise.<array>} Resolved by all rows from table
  */
@@ -122,11 +124,12 @@ db.getAll = (table, organizationID, modify = () => {}) => {
  * @param {any} value Value in column to look for
  * @param {object} data Data to update row with
  * @param {any} [organizationID] ID of organization
+ * @param {function} [modify=noop] Modify the query
  * @return {Promise} Resolved when response is sent
  * @throws restify.NotFoundError when row is missing from db
  * @throws restify.UnprocessableEntityError when body is missing
  */
-db.update = (table, column, value, data, organizationID) => {
+db.update = (table, column, value, data, organizationID, modify = () => {}) => {
   return db(table)
     .where(db.buildWhere(table, column, value, organizationID))
     .first()

--- a/services/endpoint.js
+++ b/services/endpoint.js
@@ -12,11 +12,12 @@ const endpoint = module.exports = {}
  * Get all rows from a table and return them in an object, assigned to a
  * property with the same name as the table
  * @param {string} tableName Name of a database table
+ * @param {function} modify Modify the query
  * @return {function} Endpoint handler
  */
-endpoint.getAll = (tableName) => {
+endpoint.getAll = (tableName, modify) => {
   return (req, res, next) => {
-    return db.getAll(tableName, req.user.organizationID)
+    return db.getAll(tableName, req.user.organizationID, modify)
       .then(rows => res.send({results: rows}))
       .catch(next)
   }
@@ -26,12 +27,13 @@ endpoint.getAll = (tableName) => {
  * Get a row from a table, identified by a column and value from the request
  * @param {string} tableName Name of a database table
  * @param {string} columnName Name of a column in the table
+ * @param {function} modify Modify the query
  * @return {function} Endpoint handler
  */
-endpoint.get = (tableName, columnName) => {
+endpoint.get = (tableName, columnName, modify) => {
   return (req, res, next) => {
     return db.get(tableName, columnName, req.params[columnName],
-                  req.user.organizationID)
+                  req.user.organizationID, modify)
       .then(row => res.send(row))
       .catch(next)
   }

--- a/services/endpoint.js
+++ b/services/endpoint.js
@@ -43,16 +43,17 @@ endpoint.get = (tableName, columnName, modify) => {
  * Create a row in a table, returning a descriptive message
  * @param {string} tableName Name of a database table
  * @param {string} message Message describing what the endpoint did
+ * @param {function} modify Modify the query
  * @return {function} Endpoint handler
  */
-endpoint.create = (tableName, message) => {
+endpoint.create = (tableName, message, modify) => {
   return (req, res, next) => {
     // Add organization ID if it is missing
     if (!req.body.organizationID) {
       req.body.organizationID = req.user.organizationID
     }
 
-    return db.create(tableName, req.body)
+    return db.create(tableName, req.body, modify)
       .then(([id]) => res.send({
         id,
         message
@@ -65,12 +66,13 @@ endpoint.create = (tableName, message) => {
  * Update a row in a table, returning the updated row
  * @param {string} tableName Name of a database table
  * @param {string} columnName Name of a column in the table
+ * @param {function} modify Modify the query
  * @return {function} Endpoint handler
  */
-endpoint.update = (tableName, columnName) => {
+endpoint.update = (tableName, columnName, modify) => {
   return (req, res, next) => {
     return db.update(tableName, columnName, req.body[columnName], req.body,
-                     req.user.organizationID)
+                     req.user.organizationID, modify)
       .then(updatedRow => { return res.send(updatedRow) })
       .catch(next)
   }
@@ -81,12 +83,13 @@ endpoint.update = (tableName, columnName) => {
  * @param {string} tableName Name of a database table
  * @param {string} columnName Name of a column in the table
  * @param {string} message Message describing what the endpoint did
+ * @param {function} modify Modify the query
  * @return {function} Endpoint handler
  */
-endpoint.delete = (tableName, columnName, message) => {
+endpoint.delete = (tableName, columnName, message, modify) => {
   return (req, res, next) => {
     return db.delete(tableName, columnName, req.params[columnName],
-                     req.user.organizationID)
+                     req.user.organizationID, modify)
       .then((rowsAffected) => {
         if (rowsAffected > 0) {
           res.send({message})

--- a/services/endpoint.js
+++ b/services/endpoint.js
@@ -26,13 +26,11 @@ endpoint.getAll = (tableName) => {
  * Get a row from a table, identified by a column and value from the request
  * @param {string} tableName Name of a database table
  * @param {string} columnName Name of a column in the table
- * @param {string} [paramName] Name of request parameter containing value to
- *   look for in column, if different from columnName
  * @return {function} Endpoint handler
  */
-endpoint.get = (tableName, columnName, paramName) => {
+endpoint.get = (tableName, columnName) => {
   return (req, res, next) => {
-    return db.get(tableName, columnName, req.params[paramName || columnName],
+    return db.get(tableName, columnName, req.params[columnName],
                   req.user.organizationID)
       .then(row => res.send(row))
       .catch(next)
@@ -65,15 +63,12 @@ endpoint.create = (tableName, message) => {
  * Update a row in a table, returning the updated row
  * @param {string} tableName Name of a database table
  * @param {string} columnName Name of a column in the table
- * @param {string} [paramName] Name of request parameter containing value to
- *   look for in column, if different from columnName
  * @return {function} Endpoint handler
  */
-endpoint.update = (tableName, columnName, paramName) => {
+endpoint.update = (tableName, columnName) => {
   return (req, res, next) => {
-    return db.update(tableName, paramName || columnName,
-                     req.body[paramName || columnName],
-                     req.body, req.user.organizationID)
+    return db.update(tableName, columnName, req.body[columnName], req.body,
+                     req.user.organizationID)
       .then(updatedRow => { return res.send(updatedRow) })
       .catch(next)
   }
@@ -84,14 +79,11 @@ endpoint.update = (tableName, columnName, paramName) => {
  * @param {string} tableName Name of a database table
  * @param {string} columnName Name of a column in the table
  * @param {string} message Message describing what the endpoint did
- * @param {string} [paramName] Name of request parameter containing value to
- *   look for in column, if different from columnName
  * @return {function} Endpoint handler
  */
-endpoint.delete = (tableName, columnName, message, paramName) => {
+endpoint.delete = (tableName, columnName, message) => {
   return (req, res, next) => {
-    return db.delete(tableName, paramName || columnName,
-                     req.params[paramName || columnName],
+    return db.delete(tableName, columnName, req.params[columnName],
                      req.user.organizationID)
       .then((rowsAffected) => {
         if (rowsAffected > 0) {

--- a/test/db.js
+++ b/test/db.js
@@ -79,19 +79,22 @@ test('Throws error when updating row with the wrong columns', t => {
 })
 
 test('Builds a where clause without organization ID', t => {
-  const whereClause = db.buildWhere(d.column, d.value)
+  const whereClause = db.buildWhere(d.testTableName, d.column, d.value)
   const expectedWhereClause = {}
   expectedWhereClause[d.column] = d.value
   t.deepEqual(whereClause, expectedWhereClause)
 })
 
 test('Builds a where clause with an organization ID', t => {
-  const whereClause = db.buildWhere(d.column, d.value, d.organizationID)
-  const expectedWhereClause = {
-    organizationID: d.organizationID
-  }
-  expectedWhereClause[d.column] = d.value
-  t.deepEqual(whereClause, expectedWhereClause)
+  const whereClause = db.buildWhere(d.testTableName, d.column, d.value,
+                                    d.organizationID)
+  t.deepEqual(whereClause, d.expectedWhereClause)
+})
+
+test('Builds a where clause with only organization ID', t => {
+  const whereClause = db.buildWhere(d.testTableName, null, null,
+                                    d.organizationID)
+  t.deepEqual(whereClause, d.expectedWhereClauseOrg)
 })
 
 test.after.always('Remove test table', async t => {

--- a/test/fixtures/db.json
+++ b/test/fixtures/db.json
@@ -22,5 +22,12 @@
   },
   "column": "testColumn",
   "value": "testValue",
-  "organizationID": 94
+  "organizationID": 94,
+  "expectedWhereClause": {
+    "test.organizationID": 94,
+    "testColumn": "testValue"
+  },
+  "expectedWhereClauseOrg": {
+    "test.organizationID": 94
+  }
 }


### PR DESCRIPTION
Closes #100, closes #94, and closes #78.

This adds the ability to inject endpoint-specific logic into the queries created by the endpoint service. With this ability, one can add joins with other tables or more specific `select` or `where` clauses, *without* having to totally bypass the endpoint service.

All the benefit of the abstraction with none of the limitation. 💪🏼