### PR TITLE
103/improve endpoint service error handling

### DIFF
--- a/controllers/item.js
+++ b/controllers/item.js
@@ -26,8 +26,8 @@ item.withFields = (queryBuilder) => {
 }
 
 endpoint.addAllMethods(item, 'item', 'tag')
-item.getAll = endpoint.getAll('item', item.withFields)
-item.get = endpoint.get('item', 'tag', item.withFields)
+item.getAll = endpoint.getAll('item', {modify: item.withFields})
+item.get = endpoint.get('item', 'tag', {modify: item.withFields})
 
 item.mount = app => {
   app.get({name: 'get all items', path: 'item'}, auth.verify, item.getAll)

--- a/controllers/rental.js
+++ b/controllers/rental.js
@@ -11,9 +11,12 @@ rental.withTag = (queryBuilder) => {
     .select('item.tag')
 }
 
+const messages = {conflict: 'Cannot rent item, item is already rented'}
+
 endpoint.addAllMethods(rental, 'rental', 'tag')
 rental.getAll = endpoint.getAll('rental', {modify: rental.withTag})
 rental.get = endpoint.get('rental', 'tag', {modify: rental.withTag})
+rental.create = endpoint.create('rental', {messages})
 
 rental.mount = app => {
   app.get({name: 'get all rentals', path: 'rental'}, auth.verify, rental.getAll)

--- a/controllers/rental.js
+++ b/controllers/rental.js
@@ -12,8 +12,8 @@ rental.withTag = (queryBuilder) => {
 }
 
 endpoint.addAllMethods(rental, 'rental', 'tag')
-rental.getAll = endpoint.getAll('rental', rental.withTag)
-rental.get = endpoint.get('rental', 'tag', rental.withTag)
+rental.getAll = endpoint.getAll('rental', {modify: rental.withTag})
+rental.get = endpoint.get('rental', 'tag', {modify: rental.withTag})
 
 rental.mount = app => {
   app.get({name: 'get all rentals', path: 'rental'}, auth.verify, rental.getAll)

--- a/services/endpoint.js
+++ b/services/endpoint.js
@@ -21,7 +21,7 @@ endpoint.getAll = (tableName, modify) => {
   return (req, res, next) => {
     return db.getAll(tableName, req.user.organizationID, modify)
       .then(rows => res.send({results: rows}))
-      .catch(next)
+      .catch(endpoint.handleError)
   }
 }
 
@@ -37,7 +37,7 @@ endpoint.get = (tableName, columnName, modify) => {
     return db.get(tableName, columnName, req.params[columnName],
                   req.user.organizationID, modify)
       .then(row => res.send(row))
-      .catch(next)
+      .catch(endpoint.handleError)
   }
 }
 
@@ -60,7 +60,7 @@ endpoint.create = (tableName, message, modify) => {
         id,
         message
       }))
-      .catch(next)
+      .catch(endpoint.handleError)
   }
 }
 
@@ -76,7 +76,7 @@ endpoint.update = (tableName, columnName, modify) => {
     return db.update(tableName, columnName, req.body[columnName], req.body,
                      req.user.organizationID, modify)
       .then(updatedRow => { return res.send(updatedRow) })
-      .catch(next)
+      .catch(endpoint.handleError)
   }
 }
 
@@ -99,7 +99,7 @@ endpoint.delete = (tableName, columnName, message, modify) => {
           res.send(204)
         }
       })
-      .catch(next)
+      .catch(endpoint.handleError)
   }
 }
 

--- a/test/db.js
+++ b/test/db.js
@@ -18,6 +18,13 @@ test.serial('Creates a row', async t => {
   await db.create(d.testTableName, d.testRow)
   const rows = await knex(d.testTableName)
   t.is(rows.length, 1)
+
+  // Try-catch necessary because t.throws does not work as expected
+  try {
+    db.create(d.testTableName, null)
+  } catch (err) {
+    t.pass('throws error when data is missing')
+  }
 })
 
 test.serial('Gets a row', async t => {

--- a/test/endpoint.js
+++ b/test/endpoint.js
@@ -134,6 +134,46 @@ test('Add all methods', t => {
          'all methods are defined on controller')
 })
 
+test('Choose message', t => {
+  // Uses default case when message type is not defined
+  const actualDefaultMessage = endpoint.chooseMessage('doesNotExist',
+                                                      d.customMessages)
+  // Uses custom message when passed object has the type defined
+  const actualCustomMessage = endpoint.chooseMessage('conflict',
+                                                     d.customMessages)
+  // Uses a default message for the type when passed object does not have it
+  const actualMessageDefault = endpoint.chooseMessage('badRequest',
+                                                      d.customMessages)
+  t.is(actualDefaultMessage, d.expectedDefaultMessage,
+          'default message works')
+  t.is(actualCustomMessage, d.expectedCustomMessage, 'custom message works')
+  t.is(actualMessageDefault, d.defaultBadRequestMessage,
+          'message default works')
+})
+
+test('Choose error', t => {
+  const actualBadRequest = endpoint.chooseError(d.errors[0], d.customMessages)
+  const actualMissing = endpoint.chooseError(d.errors[1], d.customMessages)
+  const actualDuplicate = endpoint.chooseError(d.errors[2], d.customMessages)
+  const actualUndefined = endpoint.chooseError(d.errors[3], d.customMessages)
+  t.true(actualBadRequest.message === d.defaultBadRequestMessage,
+         'handles bad request error')
+  t.true(actualMissing.message === d.customMessages.missing,
+         'handles missing error')
+  t.true(actualDuplicate.message === d.customMessages.conflict,
+         'handles duplicate error')
+  t.true(actualUndefined.message === d.expectedDefaultMessage,
+         'handles undefined error')
+})
+
+test('Handle error', t => {
+  const next = sinon.spy()
+
+  endpoint.handleError(d.errors[0], d.customMessages, next)
+
+  t.true(next.calledOnce, 'next handler is called')
+})
+
 test.after.always('Remove test table', async t => {
   await knex.schema.dropTable(d.table)
 })

--- a/test/endpoint.js
+++ b/test/endpoint.js
@@ -68,7 +68,7 @@ test('Create', async t => {
     send: sinon.spy()
   }
   const next = sinon.spy()
-  await endpoint.create(d.table, d.createMessage)(req, res, next)
+  await endpoint.create(d.table, d.messagesWithCreate)(req, res, next)
   t.true(res.send.calledOnce, 'route sends a response')
   t.true(res.send.calledWithMatch(sinon.match.object),
          'route responds with an object')
@@ -111,7 +111,7 @@ test('Delete', async t => {
   }
   const next = sinon.spy()
   await endpoint.delete(d.table, d.primaryKey,
-                        d.deleteMessage)(req, res, next)
+                        d.messagesWithDelete)(req, res, next)
   t.true(res.send.calledOnce, 'route sends a response')
   t.true(res.send.calledWithMatch(sinon.match.object),
          'route responds with an object')

--- a/test/fixtures/endpoint.json
+++ b/test/fixtures/endpoint.json
@@ -58,5 +58,24 @@
     "create",
     "update",
     "delete"
+  ],
+  "messageTypes": {
+    "defaultTest": "default",
+    "customTest": "conflict"
+  },
+  "expectedDefaultMessage": "something went wrong",
+  "expectedCustomMessage": "item already exists",
+  "defaultBadRequestMessage": "wrong fields in request body",
+  "customMessages": {
+    "create": "item created",
+    "delete": "item deleted",
+    "conflict": "item already exists",
+    "missing": "item does not exist"
+  },
+  "errors": [
+    {"code": "ER_BAD_FIELD_ERROR"},
+    {"code": "ER_NOT_FOUND"},
+    {"code": "ER_DUP_ENTRY"},
+    {"code": "ER_GENERIC_ERROR"}
   ]
 }

--- a/test/fixtures/endpoint.json
+++ b/test/fixtures/endpoint.json
@@ -50,8 +50,16 @@
       }
     }
   },
-  "createMessage": "row created",
-  "deleteMessage": "row deleted",
+  "messagesWithCreate": {
+    "messages": {
+      "create": "row created"
+    }
+  },
+  "messagesWithDelete": {
+    "messages": {
+      "delete": "row deleted"
+    }
+  },
   "allMethodNames": [
     "getAll",
     "get",


### PR DESCRIPTION
Closes #103 and closes #96.

This allows for custom create, delete, and error messages to be used for each endpoint via the endpoint service. It also moves error handling from the database service and into the endpoint service, which is a better separation of concerns.