### PR TITLE
89/Update item joins for brand moving to model

### DIFF
--- a/controllers/item.js
+++ b/controllers/item.js
@@ -8,13 +8,13 @@ item.withFields = (queryBuilder) => {
   return queryBuilder
     .select('item.*')
 
-  // Brand
-    .leftJoin('brand', 'item.brandID', 'brand.brandID')
-    .select('brand.name as brand')
-
   // Model
     .leftJoin('model', 'item.modelID', 'model.modelID')
     .select('model.name as model')
+
+  // Brand
+    .leftJoin('brand', 'model.brandID', 'brand.brandID')
+    .select('brand.name as brand')
 
   // Category
     .leftJoin('category', 'item.categoryID', 'category.categoryID')


### PR DESCRIPTION
Now that the brand relationship has moved from `item` to `model`, the
joins in `/item` have to change slightly to return the same results.

Closes #89.