### PR TITLE
114/Fix missing brand in item endpoint

### DIFF
--- a/controllers/item.js
+++ b/controllers/item.js
@@ -11,6 +11,7 @@ item.withFields = (queryBuilder) => {
   // Model
     .leftJoin('model', 'item.modelID', 'model.modelID')
     .select('model.name as model')
+    .select('model.brandID')
 
   // Brand
     .leftJoin('brand', 'model.brandID', 'brand.brandID')


### PR DESCRIPTION
The `brandID` field was not being selected from the model table, so
there was nothing to join the brand table on.

Closes #114.