### PR TITLE
110/Fix endpoint update function

### DIFF
--- a/services/endpoint.js
+++ b/services/endpoint.js
@@ -77,7 +77,7 @@ endpoint.create = (tableName, {modify, messages} = {}) => {
  */
 endpoint.update = (tableName, columnName, {modify, messages} = {}) => {
   return (req, res, next) => {
-    return db.update(tableName, columnName, req.body[columnName], req.body,
+    return db.update(tableName, columnName, req.params[columnName], req.body,
                      req.user.organizationID, endpoint.bindModify(modify, req))
       .then(updatedRow => { return res.send(updatedRow) })
       .catch(err => endpoint.handleError(err, messages, next))

--- a/test/endpoint.js
+++ b/test/endpoint.js
@@ -81,8 +81,13 @@ test('Update', async t => {
 
   const req = {
     body: d.updatedRow,
+    params: {},
     user: {organizationID: d.organizationID}
   }
+
+  // Add the primary key value to the parameters
+  req.params[d.primaryKey] = d.updatedRow[d.primaryKey]
+
   const res = {
     send: sinon.spy()
   }


### PR DESCRIPTION
Parameters from and endpoint's path are always defined in
`req.params`. Looking for the column name in `req.body` was requiring
all `PUT` requests to include the tag of items in the body, which was
redundant because it is already present in the URL.

Closes #110.