### PR TITLE
111/Add actual error to log output

### DIFF
--- a/services/endpoint.js
+++ b/services/endpoint.js
@@ -23,7 +23,7 @@ endpoint.getAll = (tableName, {modify, messages} = {}) => {
     return db.getAll(tableName, req.user.organizationID,
                      endpoint.bindModify(modify, req))
       .then(results => res.send({results}))
-      .catch(err => endpoint.handleError(err, messages, next))
+      .catch(err => endpoint.handleError(err, messages, next, req))
   }
 }
 
@@ -40,7 +40,7 @@ endpoint.get = (tableName, columnName, {modify, messages} = {}) => {
     return db.get(tableName, columnName, req.params[columnName],
                   req.user.organizationID, endpoint.bindModify(modify, req))
       .then(row => res.send(row))
-      .catch(err => endpoint.handleError(err, messages, next))
+      .catch(err => endpoint.handleError(err, messages, next, req))
   }
 }
 
@@ -63,7 +63,7 @@ endpoint.create = (tableName, {modify, messages} = {}) => {
         id,
         message: endpoint.chooseMessage('create', messages)
       }))
-      .catch(err => endpoint.handleError(err, messages, next))
+      .catch(err => endpoint.handleError(err, messages, next, req))
   }
 }
 
@@ -80,7 +80,7 @@ endpoint.update = (tableName, columnName, {modify, messages} = {}) => {
     return db.update(tableName, columnName, req.params[columnName], req.body,
                      req.user.organizationID, endpoint.bindModify(modify, req))
       .then(updatedRow => { return res.send(updatedRow) })
-      .catch(err => endpoint.handleError(err, messages, next))
+      .catch(err => endpoint.handleError(err, messages, next, req))
   }
 }
 
@@ -103,7 +103,7 @@ endpoint.delete = (tableName, columnName, {modify, messages} = {}) => {
           res.send(204)
         }
       })
-      .catch(err => endpoint.handleError(err, messages, next))
+      .catch(err => endpoint.handleError(err, messages, next, req))
   }
 }
 
@@ -163,8 +163,10 @@ endpoint.chooseError = (err, messages) => {
  * @param {error} err Error from database
  * @param {object} [messages] Messages for endpoint events
  * @param {function} next Next handler in chain; will be given error
+ * @param {object} req Restify request
  */
-endpoint.handleError = (err, messages, next) => {
+endpoint.handleError = (err, messages, next, req) => {
+  req.log.error(err)
   next(endpoint.chooseError(err, messages))
 }
 

--- a/services/log.js
+++ b/services/log.js
@@ -18,7 +18,7 @@ const streams = [
 // Create a Bunyan logger.
 const log = module.exports = new Bunyan({
   name: config.name,
-  streams: streams,
+  streams,
   serializers: restify.bunyan.serializers
 })
 

--- a/test/endpoint.js
+++ b/test/endpoint.js
@@ -173,10 +173,16 @@ test('Choose error', t => {
 
 test('Handle error', t => {
   const next = sinon.spy()
+  const req = {
+    log: {
+      error: sinon.spy()
+    }
+  }
 
-  endpoint.handleError(d.errors[0], d.customMessages, next)
+  endpoint.handleError(d.errors[0], d.customMessages, next, req)
 
   t.true(next.calledOnce, 'next handler is called')
+  t.true(req.log.error.calledOnce, 'error is logged with request logger')
 })
 
 test.after.always('Remove test table', async t => {


### PR DESCRIPTION
This will print the error that caused an error response to be
returned. In the logs at trace level, it will be printed in between the
request and response so that it is easy to locate. At info level, it
will be printed right after the request.

Closes #111.