### PR TITLE
206/Add admin check to user ID check middleware

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -165,7 +165,6 @@ auth.checkUserMatches = function checkUserMatches (req, res, next) {
   if (req.user.userID === Number.parseInt(req.params.userID, 10)) {
     return next()
   } else {
-    return next(new restify.ForbiddenError(
-      'Must be an administrator to access other users\' data'))
+    return auth.checkAdmin(req, res, next)
   }
 }


### PR DESCRIPTION
The middleware would return the error "Must be an administrator to
access other users' data" without checking if the requesting user was
an administrator or not.

Closes #206.