### PR TITLE
227/Fix get all rentals

### DIFF
--- a/controllers/rental.js
+++ b/controllers/rental.js
@@ -7,7 +7,10 @@ const paginate = require('../services/paginate')
 const rental = module.exports
 
 rental.withBarcodeAndPagination = (req, queryBuilder) => {
-  return rental.withBarcode(req, queryBuilder)
+  return queryBuilder
+    .select('rental.*')
+    .leftJoin('item', 'rental.itemID', 'item.itemID')
+    .select('item.barcode')
     .modify(paginate.paginateQuery, req, 'rental')
 }
 


### PR DESCRIPTION
The endpoint's modify function was relying on another function that
had been removed, so the endpoint was failing to send a response.

Closes #227.