### PR TITLE
331/Fix wrong method signature on options handler

### DIFF
--- a/controllers/options.js
+++ b/controllers/options.js
@@ -4,16 +4,16 @@ const cors = require('./cors')
 
 const options = module.exports
 
-options.handle = (req, res, next) => {
+options.handle = (req, res, err, callback) => {
   // Handle OPTIONS requests
   if (req.method.toLowerCase() === 'options') {
     cors.prepareResponse(req, res)
     res.send(204)
-    return next()
+    return callback()
 
   // If not OPTIONS request, rethrow error
   } else {
     res.send(new restify.MethodNotAllowedError())
-    return next()
+    return callback()
   }
 }

--- a/test/options.js
+++ b/test/options.js
@@ -11,8 +11,8 @@ test('Responds with 204 NO CONTENT when method is OPTIONS', t => {
     header: sinon.spy(),
     send: sinon.spy()
   }
-  const next = sinon.spy()
-  options.handle(fixt.reqOptions, res, next)
+  const callback = sinon.spy()
+  options.handle(fixt.reqOptions, res, null, callback)
   t.true(res.send.called, 'response sent')
   t.true(res.send.calledWithMatch(sinon.match.same(204)),
     'responds with 204')
@@ -24,8 +24,8 @@ test('Responds with 405 METHOD NOT ALLOWED when method is not OPTIONS', t => {
     header: sinon.spy(),
     send: sinon.spy()
   }
-  const next = sinon.spy()
-  options.handle(fixt.req, res, next)
+  const callback = sinon.spy()
+  options.handle(fixt.req, res, null, callback)
   t.true(res.send.called, 'response sent')
   t.true(res.send.calledWithMatch(new restify.MethodNotAllowedError()),
     'responds with Restify 405 error')


### PR DESCRIPTION
The `OPTIONS` request handler function had the method signature of a `restify.use()` function but should have had the signature of a `restify.on()` function because that is how it is used.

Closes #331.