### PR TITLE
337/Fix create rental endpoint

### DIFF
--- a/controllers/rental.js
+++ b/controllers/rental.js
@@ -51,7 +51,7 @@ rental.create = (req, res, next) => {
       rental.barcode = item.barcode
       return rental
     })
-    return Promise.all(rentals.map(rental => db.create('rental', 'rentalID', rental)))
+    return db.create('rental', 'rentalID', rentals)
       .then(results => {
         const message = results.length > 1 ? messages.createPlural : messages.create
         res.send({


### PR DESCRIPTION
Instead of using a separate `insert into` query for each rental, insert all of them in a single query. This also provides the desired transactional behavior: if one rental cannot be created, then none of them will be created and the response will be an error.

Closes #337.