### PR TITLE
hotfix/item custom field value (2)

### DIFF
--- a/controllers/item.js
+++ b/controllers/item.js
@@ -106,9 +106,13 @@ item.withCustomFields = (req, queryBuilder) => {
         .leftJoin('customFieldCategory', 'customField.customFieldID', 'customFieldCategory.customFieldID')
         // Get values
         .leftJoin('itemCustomField', 'customField.customFieldID', 'itemCustomField.customFieldID')
-        // Only get rows for this item
-        .where('itemCustomField.barcode', req.params.barcode)
-        .where('customFieldCategory.categoryID', null)
+        // Only get item custom fields for this item
+        .where(function () {
+          this.where('itemCustomField.barcode', req.params.barcode)
+            // Include unset item custom fields to avoid losing custom fields without values
+            .orWhere('itemCustomField.barcode', null)
+        })
+        .andWhere('customFieldCategory.categoryID', null)
         .andWhere('customField.organizationID', req.user.organizationID)
     })
 }

--- a/controllers/item.js
+++ b/controllers/item.js
@@ -87,7 +87,6 @@ item.withCustomFields = (req, queryBuilder) => {
     'customField.name as customFieldName',
     'customField.customFieldID',
     'customField.organizationID',
-    'category.name as categoryName',
     'itemCustomField.value'
   ]
   return queryBuilder
@@ -95,8 +94,6 @@ item.withCustomFields = (req, queryBuilder) => {
     // Get custom fields for the item's category
     .join('customFieldCategory', 'item.categoryID', 'customFieldCategory.categoryID')
     .join('customField', 'customFieldCategory.customFieldID', 'customField.customFieldID')
-    // Get category
-    .join('category', 'customFieldCategory.categoryID', 'category.categoryID')
     // Get values
     .leftJoin('itemCustomField', 'customField.customFieldID', 'itemCustomField.customFieldID')
     // Only get rows for this item
@@ -107,8 +104,6 @@ item.withCustomFields = (req, queryBuilder) => {
         .from('customField')
         // Join all custom fields with all categories (`categoryID = null` if no categories are specified)
         .leftJoin('customFieldCategory', 'customField.customFieldID', 'customFieldCategory.customFieldID')
-        // Get nonexistent category so that the columns are the same as the previous query and the union succeeds
-        .leftJoin('category', 'customFieldCategory.categoryID', 'category.categoryID')
         // Get values
         .leftJoin('itemCustomField', 'customField.customFieldID', 'itemCustomField.customFieldID')
         // Only get rows for this item
@@ -342,15 +337,10 @@ item.mount = app => {
    * @apiPermission User
    * @apiVersion 2.0.0
    *
-   * @apiDescription The `categoryName` is the name of the item's category, and also the category that the custom field
-   *   applies to. When `categoryName` is `null`, the custom field applies to all categories. When `value` is `null`, no
-   *   value has been set for this custom field for this item.
-   *
    * @apiExample {json} Response Format
    * {
    *   "results": [
    *     {
-   *       "categoryName": "",
    *       "customFieldID": 0,
    *       "customFieldName": "",
    *       "organizationID": 0,


### PR DESCRIPTION
Fix get item custom field missing results
When a custom field applies to all categories (it has no rows in `customFieldCategory`) and has no value, it was not being returned by this endpoint because the `where` statement expects `itemCustomField.barcode` to be set. Allowing that field to be `null` ensures that these custom fields will be present in the response.

Remove category name from get item custom fields response
This field was causing duplicate results when a custom field was in multiple categories.