### PR TITLE
hotfix/item custom field values (3)

### DIFF
--- a/controllers/item.js
+++ b/controllers/item.js
@@ -104,13 +104,10 @@ item.withCustomFields = (req, queryBuilder) => {
         .from('customField')
         // Join all custom fields with all categories (`categoryID = null` if no categories are specified)
         .leftJoin('customFieldCategory', 'customField.customFieldID', 'customFieldCategory.customFieldID')
-        // Get values
-        .leftJoin('itemCustomField', 'customField.customFieldID', 'itemCustomField.customFieldID')
-        // Only get item custom fields for this item
-        .where(function () {
-          this.where('itemCustomField.barcode', req.params.barcode)
-            // Include unset item custom fields to avoid losing custom fields without values
-            .orWhere('itemCustomField.barcode', null)
+        // Get item custom fields for this item
+        .leftJoin('itemCustomField', function () {
+          this.on('customField.customFieldID', 'itemCustomField.customFieldID')
+            .on('itemCustomField.barcode', db.raw('?', [req.params.barcode]))
         })
         .andWhere('customFieldCategory.categoryID', null)
         .andWhere('customField.organizationID', req.user.organizationID)


### PR DESCRIPTION
Fix item custom field values when item custom field has a value

When the custom field has a value for any item in the organization, it was no longer returned for any items that *do not* have a value for that custom field. This change makes it so that custom fields that apply to all categories will only be `join`ed with the item custom field table if the current item's barcode matches. Using a second `on` clause in the `join` is a better approach than using two `where` clauses.