### PR TITLE
Fix create external renter path typo

### DIFF
--- a/controllers/external-renter.js
+++ b/controllers/external-renter.js
@@ -77,7 +77,7 @@ externalRenter.mount = app => {
    * @apiUse ExternalRenterResponse
    * @apiUse InvalidSubscriptionResponse
    */
-  app.put({name: 'create external renter', path: 'externalRenter'}, auth.verify, checkSubscription,
+  app.put({name: 'create external renter', path: 'external-renter'}, auth.verify, checkSubscription,
     externalRenter.create)
   /**
    * @api {put} /external-renter/:externalRenterID Update an external renter


### PR DESCRIPTION
Sending a request to create a new external renter with `PUT /external-renter` resulted in a `405 (Method Not Allowed)` because of this typo.