### PR TITLE
hotfix/cross-organization categories in item custom fields

### DIFF
--- a/controllers/item.js
+++ b/controllers/item.js
@@ -337,6 +337,8 @@ item.mount = app => {
    * {
    *   "results": [
    *     {
+   *       "barcode": "",
+   *       "categoryID": 0,
    *       "customFieldID": 0,
    *       "customFieldName": "",
    *       "organizationID": 0,

--- a/controllers/item.js
+++ b/controllers/item.js
@@ -85,17 +85,21 @@ item.forItem = (req, queryBuilder) => {
 item.withCustomFields = (req, queryBuilder) => {
   return queryBuilder
     .select(
+      'item.barcode',
+      'item.categoryID',
       'customField.name as customFieldName',
       'customField.customFieldID',
-      'customField.organizationID',
-      'itemCustomField.value'
+      'customField.organizationID'
+      , 'itemCustomField.value'
     )
     // Join custom fields with their categories (`categoryID = null` if no categories are specified)
     .leftJoin('customFieldCategory', 'customField.customFieldID', 'customFieldCategory.customFieldID')
     // Get items that match each custom field
     .join('item', function () {
-      this.on('customFieldCategory.categoryID', 'item.categoryID')
-        .orOnNull('customFieldCategory.categoryID')
+      this.on(function () {
+        this.andOn('customFieldCategory.categoryID', 'item.categoryID')
+          .orOnNull('customFieldCategory.categoryID')
+      }).andOn('customField.organizationID', 'item.organizationID')
     })
     // Get item custom fields for this item and custom field
     .leftJoin('itemCustomField', function () {


### PR DESCRIPTION
The query for item custom fields included a `join` with all items that matched on `categoryID`, which would only match with items in the same organization, or `categoryID is null`, which would match with all items in the database. The latter could cause strange problems. Adding an `and organizationID` to the `join` fixes the problem.