### PR TITLE
364/Restrict deletion of external renters

### DIFF
--- a/controllers/external-renter.js
+++ b/controllers/external-renter.js
@@ -105,6 +105,6 @@ externalRenter.mount = app => {
    * @apiUse EndpointDelete
    * @apiUse InvalidSubscriptionResponse
    */
-  app.del({name: 'delete external renter', path: 'external-renter/:externalRenterID'}, auth.verify, checkSubscription,
-    externalRenter.delete)
+  app.del({name: 'delete external renter', path: 'external-renter/:externalRenterID'}, auth.verify, auth.checkAdmin,
+    checkSubscription, externalRenter.delete)
 }


### PR DESCRIPTION
Deleting an external renter changes history, because it sets `rental.externalRenterID` to `null` on any rentals that had that external renter. Because of this, it should be an admin-only feature to delete external renters.

Closes #364.