### PR TITLE
391/Fix query parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ app.use(restify.plugins.requestLogger())
 
 // Parse incoming request body and query parameters
 app.use(restify.plugins.bodyParser())
-app.use(restify.plugins.queryParser())
+app.use(restify.plugins.queryParser({mapParams: true}))
 
 // Set name for links middleware
 const links = restifyLinks()


### PR DESCRIPTION
Closes #391.

Restify 5.x up no longer maps query parameters to `req.params` by default.